### PR TITLE
Change API To Make Assertions More Readable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,10 @@ npm install @lynchbox/assert;
 ```node
 import assert from @lynchbox/assert;
 
-assert.between(5, 1, 10);
-assert.contains(`I am serious…and don't call me Shirley`, 'surely');
-assert.eq('same', 'same');
-assert.greaterOrEqualThan(value: number, limit: number);
+assert(value: number).between(lowerlimit: number, upperLimit: number);
+assert(value: string).contains('surely');
+assert(value: string).eq('same');
+assert(value: number).greaterOrEqualThan(limit: number);
 
 ```
 

--- a/src/functions/between/index.test.ts
+++ b/src/functions/between/index.test.ts
@@ -3,22 +3,22 @@ import between from './';
 
 describe('between', () => {
     it ('should pass if value is between min and max', () => {
-        expect(between(5, 1, 10)).toBeTruthy();
+        expect(between(5)(1, 10)).toBeTruthy();
     });
 
     it ('should throw exception if value is outwith min', () => {
         expect(() => {
-            between(1, 5, 10);
+            between(1)(5, 10);
         }).toThrowError(AssertionFailedException);
     });
 
     it ('should throw exception if value is outwith max', () => {
         expect(() => {
-            between(11, 5, 10);
+            between(11)(5, 10);
         }).toThrowError(AssertionFailedException);
     });
 
     it ('should pass if the value is null', () => {
-        expect(between(null, 1, 3)).toBeTruthy();
+        expect(between(null)(1, 3)).toBeTruthy();
     })
 });

--- a/src/functions/between/index.ts
+++ b/src/functions/between/index.ts
@@ -7,7 +7,7 @@ import AssertionFailedException from '../../Exceptions/AssertionFailedException'
  * @param lowerLimit 
  * @param upperLimit 
  */
-const between = (value: number | null, lowerLimit: number, upperLimit: number) => {
+const between = (value: number | null) => (lowerLimit: number, upperLimit: number) => {
     if (!value) {
         return true;
     }

--- a/src/functions/contains/index.test.ts
+++ b/src/functions/contains/index.test.ts
@@ -3,20 +3,20 @@ import contains from './';
 
 describe('contains', () => {
     it ('should pass if value contains the needle at the end', () => {
-        expect(contains('hello world', 'world')).toBeTruthy();
+        expect(contains('hello world')('world')).toBeTruthy();
     });
 
     it ('should pass if value contains the needle at the start', () => {
-        expect(contains('hello world', 'hello')).toBeTruthy();
+        expect(contains('hello world')('hello')).toBeTruthy();
     });
 
     it ('should pass if value contains the needle in the middle', () => {
-        expect(contains('hello world', 'lo w')).toBeTruthy();
+        expect(contains('hello world')('lo w')).toBeTruthy();
     });
 
     it ('should throw exception if value does not contain the needle', () => {
         expect(() => {
-            contains(`Frankly, my dear, I don't give a damn.`, 'Gone With the Wind');
+            contains(`Frankly, my dear, I don't give a damn.`)('Gone With the Wind');
         }).toThrowError(AssertionFailedException);
     });
 });

--- a/src/functions/contains/index.ts
+++ b/src/functions/contains/index.ts
@@ -6,7 +6,7 @@ import AssertionFailedException from '../../Exceptions/AssertionFailedException'
  * @param value 
  * @param needle
  */
-const contains = (value: string, needle: string) => {
+const contains = (value: string) => (needle: string) => {
     if (!value.includes(needle)) {
         throw new AssertionFailedException(`Provided "${value}" does not contain "${needle}"`);
     }

--- a/src/functions/eq/index.test.ts
+++ b/src/functions/eq/index.test.ts
@@ -3,13 +3,13 @@ import eq from './';
 
 describe('eq', () => {
     it ('should pass if values are equal', () => {
-        expect(eq('thing', 'thing')).toBeTruthy();
-        expect(eq('ding', 'ding')).toBeTruthy();
+        expect(eq('thing')('thing')).toBeTruthy();
+        expect(eq('ding')('ding')).toBeTruthy();
     });
 
     it ('should throw exception if values are not equal', () => {
         expect(() => {
-            eq('ding', 'dong');
+            eq('ding')('dong');
         }).toThrowError(AssertionFailedException);
     });
 });

--- a/src/functions/eq/index.ts
+++ b/src/functions/eq/index.ts
@@ -6,7 +6,7 @@ import AssertionFailedException from '../../Exceptions/AssertionFailedException'
  * @param value 
  * @param value2
  */
-const eq = (value: string, value2: string) => {
+const eq = (value: string) => (value2: string) => {
     if (value !== value2) {
         throw new AssertionFailedException(`Provided "${value}" does not equal expected value "${value2}"`);
     }

--- a/src/functions/greaterOrEqualThan/index.test.ts
+++ b/src/functions/greaterOrEqualThan/index.test.ts
@@ -3,16 +3,16 @@ import greaterOrEqualThan from './';
 
 describe('greaterOrEqualThan', () => {
     it ('should pass if value is greater than the limit', () => {
-        expect(greaterOrEqualThan(10, 5)).toBeTruthy();
+        expect(greaterOrEqualThan(10)(5)).toBeTruthy();
     });
 
     it ('should pass if value is equal to the limit', () => {
-        expect(greaterOrEqualThan(10, 10)).toBeTruthy();
+        expect(greaterOrEqualThan(10)(10)).toBeTruthy();
     });
 
     it ('should throw exception if value is less than the limit', () => {
         expect(() => {
-            expect(greaterOrEqualThan(5, 10))
+            expect(greaterOrEqualThan(5)(10))
         }).toThrowError(AssertionFailedException);
     });
 });

--- a/src/functions/greaterOrEqualThan/index.ts
+++ b/src/functions/greaterOrEqualThan/index.ts
@@ -6,7 +6,7 @@ import AssertionFailedException from '../../Exceptions/AssertionFailedException'
  * @param value 
  * @param limit
  */
-const greaterOrEqualThan = (value: number, limit: number) => {
+const greaterOrEqualThan = (value: number) => (limit: number) => {
     if (value < limit) {
         throw new AssertionFailedException(`Provided "${value}" is not greater or equal than "${limit}".`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const Assert = (value: any) => {
     return {
         between: between(value),
         contains: contains(value),
-        eq,
+        eq: eq(value),
         greaterOrEqualThan,
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const Assert = (value: any) => {
 
     return {
         between: between(value),
-        contains,
+        contains: contains(value),
         eq,
         greaterOrEqualThan,
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const Assert = (value: any) => {
         between: between(value),
         contains: contains(value),
         eq: eq(value),
-        greaterOrEqualThan,
+        greaterOrEqualThan: greaterOrEqualThan(value),
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,14 @@ import contains from './functions/contains';
 import eq from './functions/eq';
 import greaterOrEqualThan from './functions/greaterOrEqualThan';
 
-const Assert = {
-    between,
-    contains,
-    eq,
-    greaterOrEqualThan,
+const Assert = (value: any) => {
+
+    return {
+        between: between(value),
+        contains,
+        eq,
+        greaterOrEqualThan,
+    }
 }
 
 export default Assert;


### PR DESCRIPTION
## About
Split the value into the top level api to make the assertion more readable.

**Was**
```
assert.between(5 ,10, 15);
```

**Now**
```
assert(5).between(10, 15);
```

There is now clear separation between the target value and is more consistent with other JS apis like Jest.